### PR TITLE
Fix SQRT output error when operand B is a NaN

### DIFF
--- a/hdl/norm_div_sqrt_mvp.sv
+++ b/hdl/norm_div_sqrt_mvp.sv
@@ -125,7 +125,7 @@ module norm_div_sqrt_mvp
            NV_OP_S = SNaN_SI;
          end
 
-      else if(NaN_b_SI)   //if b is NaN, return NaN
+      else if(NaN_b_SI && Div_enable_SI)   //if b is NaN, return NaN
         begin
           Div_Zero_S=1'b0;
           Exp_OF_S=1'b0;


### PR DESCRIPTION
SQRT operation only use the operand A and should not care if operand B is a NaN.

This issue is also presented at issue #7 .