### PR TITLE
Bugfix: unset DZ flag when dividing 0 by 0.

### DIFF
--- a/hdl/norm_div_sqrt_mvp.sv
+++ b/hdl/norm_div_sqrt_mvp.sv
@@ -187,7 +187,7 @@ module norm_div_sqrt_mvp
        begin
          if(Div_enable_SI&&Zero_b_SI)
            begin
-              Div_Zero_S=1'b1;
+              Div_Zero_S=1'b0;
               Exp_OF_S=1'b0;
               Exp_UF_S=1'b0;
               Mant_res_norm_D={1'b0,C_MANT_NAN_FP64};


### PR DESCRIPTION
Hi!

This fixes #17.
I remain at your disposal.

Thanks!
Flavien