### PR TITLE
DivSqrt FP32 divide: NX on inexact (family b) + drop spurious OF on inf-operand divide/sqrt (family f, also fixes #25)

### DIFF
--- a/hdl/control_mvp.sv
+++ b/hdl/control_mvp.sv
@@ -77,7 +77,8 @@ module control_mvp
 
    output logic [C_MANT_FP64+4:0]                     Mant_result_prenorm_DO,
  //  output logic [3:0]                                 Round_bit_DO,
-   output logic [C_EXP_FP64+1:0]                      Exp_result_prenorm_DO
+   output logic [C_EXP_FP64+1:0]                      Exp_result_prenorm_DO,
+   output logic                                       Div_R_zero_SO  // final division remainder is exactly zero
  );
 
    logic  [C_MANT_FP64+1+4:0]                         Partial_remainder_DN,Partial_remainder_DP; //58bits,r=q+2
@@ -2416,6 +2417,22 @@ module control_mvp
              Partial_remainder_DP <= Partial_remainder_DN;
           end
     end
+
+   /////////////////////////////////////////////////////////////////////////////
+   // Final-remainder-zero detection for division                             //
+   /////////////////////////////////////////////////////////////////////////////
+   // The quotient register only ever holds mant+3 (FP32: 27) quotient bits,
+   // so any inexactness below those bits is visible exclusively as a
+   // non-zero final remainder.  IEEE 754-2008 7.6 (inexact) therefore needs
+   // this signal.  For the non-restoring iteration implemented here the
+   // division is exact iff the partial remainder ends at 0 or at -D.  The
+   // working vector keeps the remainder left-aligned with the bits below the
+   // format's mantissa exactly zero, so both states compare for full words.
+   logic [C_MANT_FP64+5:0]   Div_neg_denominator_D;
+   assign Div_neg_denominator_D = ~{Denominator_se_D,4'b0} + 1'b1;
+
+   assign Div_R_zero_SO = (Partial_remainder_DP == '0)
+                        | (Partial_remainder_DP == Div_neg_denominator_D);
 
    logic [C_MANT_FP64+4:0] Quotient_DN;
 

--- a/hdl/div_sqrt_top_mvp.sv
+++ b/hdl/div_sqrt_top_mvp.sv
@@ -92,6 +92,7 @@ module div_sqrt_top_mvp
    logic FP64_S;
    logic FP16_S;
    logic FP16ALT_S;
+   logic Div_R_zero_S;
 
 
  preprocess_mvp  preprocess_U0
@@ -149,7 +150,8 @@ module div_sqrt_top_mvp
    .Ready_SO              (Ready_SO           ),
    .Done_SO               (Done_SO            ),
    .Exp_z_DO              (Exp_z_D            ),
-   .Mant_z_DO             (Mant_z_D           )
+   .Mant_z_DO             (Mant_z_D           ),
+   .Div_R_zero_SO         (Div_R_zero_S       )
     );
 
 
@@ -159,6 +161,7 @@ module div_sqrt_top_mvp
    .Exp_in_DI             (Exp_z_D            ),
    .Sign_in_DI            (Sign_z_D           ),
    .Div_enable_SI         (Div_enable_S       ),
+   .Div_R_zero_SI         (Div_R_zero_S       ),
    .Sqrt_enable_SI        (Sqrt_enable_S      ),
    .Inf_a_SI              (Inf_a_S            ),
    .Inf_b_SI              (Inf_b_S            ),

--- a/hdl/norm_div_sqrt_mvp.sv
+++ b/hdl/norm_div_sqrt_mvp.sv
@@ -49,6 +49,7 @@ module norm_div_sqrt_mvp
    input logic signed [C_EXP_FP64+1:0]          Exp_in_DI,
    input logic                                  Sign_in_DI,
    input logic                                  Div_enable_SI,
+   input logic                                  Div_R_zero_SI,  // final division remainder is exactly zero
    input logic                                  Sqrt_enable_SI,
    input logic                                  Inf_a_SI,
    input logic                                  Inf_b_SI,
@@ -160,8 +161,12 @@ module norm_div_sqrt_mvp
             Sign_res_D=1'b0;
             NV_OP_S = 1'b1;
           end else begin
+            // inf/finite (and sqrt(+inf)) deliver an exact infinity; no
+            // exception is involved.  Overflow (IEEE 754-2008 7.4) only
+            // applies when a finite intermediate result exceeds the largest
+            // finite number, so OF must not be raised here.
             Div_Zero_S=1'b0;
-            Exp_OF_S=1'b1;
+            Exp_OF_S=1'b0;
             Exp_UF_S=1'b0;
             Mant_res_norm_D= '0;
             Exp_res_norm_D='1;
@@ -173,8 +178,11 @@ module norm_div_sqrt_mvp
 
       else if(Div_enable_SI&&Inf_b_SI)
         begin
+          // finite/inf delivers an exact zero; no exception is involved
+          // (IEEE 754-2008 7.4: overflow requires a finite result that
+          // exceeds the largest finite number after rounding).
           Div_Zero_S=1'b0;
-          Exp_OF_S=1'b1;
+          Exp_OF_S=1'b0;
           Exp_UF_S=1'b0;
           Mant_res_norm_D= '0;
           Exp_res_norm_D='0;
@@ -395,7 +403,17 @@ module norm_div_sqrt_mvp
       end
     end
 
-   assign Mant_rounded_S = (|(Mant_lower_D))| Mant_sticky_bit_D;
+   // The iteration computes only a few quotient bits below the mantissa
+   // (FP32: 3); any inexactness below them is visible exclusively as a
+   // non-zero final division remainder, which must contribute to the sticky
+   // information used for the inexact flag (IEEE 754-2008 7.6).  The special
+   // operand cases do not run the iteration, so their remainder state carries
+   // no meaning and is masked out here.
+   logic                                   Div_Rem_Sticky_S;
+   assign Div_Rem_Sticky_S = Div_enable_SI && (~Div_R_zero_SI)
+        && ~(NaN_a_SI | NaN_b_SI | Inf_a_SI | Inf_b_SI | Zero_a_SI | Zero_b_SI);
+
+   assign Mant_rounded_S = (|(Mant_lower_D))| Mant_sticky_bit_D | Div_Rem_Sticky_S;
 
 
 

--- a/hdl/nrbd_nrsc_mvp.sv
+++ b/hdl/nrbd_nrsc_mvp.sv
@@ -62,7 +62,8 @@ module nrbd_nrsc_mvp
    output logic                                Ready_SO,
    output logic                                Done_SO,
    output logic  [C_MANT_FP64+4:0]             Mant_z_DO,
-   output logic [C_EXP_FP64+1:0]               Exp_z_DO
+   output logic [C_EXP_FP64+1:0]               Exp_z_DO,
+   output logic                                Div_R_zero_SO  // final division remainder is exactly zero
     );
 
 
@@ -96,7 +97,8 @@ control_mvp         control_U0
    .Ready_SO                                 (Ready_SO                        ),
    .Done_SO                                  (Done_SO                         ),
    .Mant_result_prenorm_DO                   (Mant_z_DO                       ),
-   .Exp_result_prenorm_DO                    (Exp_z_DO                        )
+   .Exp_result_prenorm_DO                    (Exp_z_DO                        ),
+   .Div_R_zero_SO                            (Div_R_zero_SO                   )
 );
 
 


### PR DESCRIPTION
Fixes the still-open flag families from #29 (FP32/RNE divide). Companion characterization + reproduction TB are in #29; this is the fix half, rebased onto current master 917dd79c and reduced to the families master does not already address (#16/#18 fixed c/d/e).


Companion to the characterization issue draft `cvfpu_pulp_divsqrt_issue.md`.
This is the **fix** half, **rebased onto current upstream master** and reduced
to the families that are still open there.

* Target repo: `pulp-platform/fpu_div_sqrt_mvp`
* Base revision: `917dd79cb2dc1a8f43df1a84e0e4231508a980e9` (current `master`;
  = Release 1.0.4 `86e1f558` + #16 `nx_when_uf_or_of` + #18 `no_div_by_zero`).
* Patch series (apply `-p1` from repo root):
  * `0001-divsqrt-flag-family-fixes.patch`  → **PR-A** (Tier A, validated)
  * `0002-divsqrt-rne-remainder-sticky-roundup.patch` → **PR-B** (Tier B,
    needs sqrt/other-format/other-rounding regression before submission)

Both patches live at `examples/patches/` in this repository and apply cleanly
(`git apply --check -p1`) to a pristine `917dd79c` checkout.

---

## What master already fixes (and why PR-A shrank)

Our original characterization had six families; the original PR-A fixed b,c,d,e,f.
On current master, **#16 and #18 already fix c, d, e**:

* **#16** (`In_Exact_S |= Exp_OF_S | Exp_UF_S`) ⇒ NX now asserts on overflow
  (family c) and on total underflow to zero (family d). Reference-verified PASS.
* **#18** (`Div_Zero_S = 1'b0` in the 0/0 branch) ⇒ no spurious DZ on 0/0
  (family e). Reference-verified PASS.

So **PR-A is reduced to the still-open flag families {b, f}**, plus one small
refinement to #16's underflow gating (see "Refinement" below). PR-B (family a
round-up) is unchanged and remains a separate, regression-gated PR.

### The still-open set on master (empirical, reference simulator)

Re-running the 17-witness TB on **pristine master `917dd79c`**: 4 sanity PASS,
6 rows of (c)/(d)/(e) PASS, **9 rows of (a)×2 + (b)×5 + (f)×2 FAIL**.

---

## PR-A (reduced) — `0001-divsqrt-flag-family-fixes.patch`

Families **(b)** and **(f)**. Result bits unchanged; flags corrected. Also
drops the spurious OF on **sqrt(+inf)** (the family-(f) inf branch is shared
with sqrt — independently fixes #25).

| File | Hunk | Family | What it does | IEEE 754-2008 |
|------|------|--------|--------------|---------------|
| `hdl/control_mvp.sv` | port `Div_R_zero_SO` + remainder-zero detector (`Div_neg_denominator_D`, compare `Partial_remainder_DP` to 0 or −D) | (b) plumbing | new comb. output: "final division remainder is exactly zero" | §7.6 |
| `hdl/nrbd_nrsc_mvp.sv` | passthrough port + wiring of `Div_R_zero_SO` | (b) plumbing | wire control→top | — |
| `hdl/div_sqrt_top_mvp.sv` | `Div_R_zero_S` wire; connect nrbd→norm | (b) plumbing | wire to consumer | — |
| `hdl/norm_div_sqrt_mvp.sv` | `Div_R_zero_SI` input port | (b) plumbing | receive signal | — |
| `hdl/norm_div_sqrt_mvp.sv` | inf/finite branch `Exp_OF_S=1'b1→1'b0` | (f) | exact ∞ raises no OF (also fixes **sqrt(+inf)**, cf. #25) | §7.4 |
| `hdl/norm_div_sqrt_mvp.sv` | finite/inf branch `Exp_OF_S=1'b1→1'b0` | (f) | exact 0 raises no OF | §7.4 |
| `hdl/norm_div_sqrt_mvp.sv` | `Div_Rem_Sticky_S` + `Mant_rounded_S` ← it | (b) | non-zero remainder ⇒ inexact (NX, via master's `In_Exact_S \| Mant_rounded_S`) | §7.6 |

`Div_Rem_Sticky_S = Div_enable_SI && ~Div_R_zero_SI && ~(NaN/Inf/Zero operands)`;
it is zero on every sqrt and special-operand cycle. It feeds `Mant_rounded_S`,
which master's `In_Exact_S` already ORs into NX — so family (b) needs **no** edit
to the `In_Exact_S`/`Fflags_SO` lines that #16 touched (avoids a merge collision
with #16 and keeps the diff minimal).

### What PR-A no longer contains (vs the old pin-targeted PR-A)

Dropped because master already covers them: the `In_Exact_S |= Exp_OF_S`
overflow-NX term (c, now #16), the underflow sticky-capture / `Mant_sticky_lost_S`
/ FP32 `Mant_sticky_bit_D` plumbing and the `Exp_UF_S` NX term (d, now #16's
raw-UF OR), the `Exp_OF_round_S` rounding-overflow term, and the 0/0
`Div_Zero_S` flip (e, now #18). The remainder-sticky plumbing for (b) and the
two inf-branch OF flips for (f) are all that survive.

### Refinement note for #16 (optional, can be a follow-up)

#16 ORs the *raw* `Exp_UF_S` into NX, so an **exact** subnormal/underflow result
now spuriously carries NX (reference-verified: `00800000/40000000 = 00400000`
flags `00011`, IEEE `00000`). The §7.5 default is "UF signals only when the
result is also inexact", i.e. NX from UF should be gated `Exp_UF_S & In_Exact_S`.
This is a one-line tightening (`In_Exact_S` would drop the `Exp_UF_S` term, and
`Fflags_SO`'s UF bit would become `Exp_UF_S & In_Exact_S`). It is **not** in
0001 (keeps PR-A scoped to the still-open families and avoids re-touching #16's
line); flagged here and in the issue draft as a recommended follow-up.

---

## PR-B — `0002-divsqrt-rne-remainder-sticky-roundup.patch` (1 file, 1 logical line)

| File | Hunk | Family | What it does | IEEE 754-2008 |
|------|------|--------|--------------|---------------|
| `hdl/norm_div_sqrt_mvp.sv` | `Mant_roundUp_S` (RNE arm) ← OR in `Div_Rem_Sticky_S` | (a) | non-zero remainder above midpoint ⇒ round up | §4.3.1 |

Only hunk that changes a *delivered result*. In the sqrt-shared SRT round logic;
the new term is `Div_enable_SI`-gated, so sqrt is unaffected in simulation, but
other formats/rounding modes were not swept — separate-PR / needs-regression.
Depends on PR-A (`Div_Rem_Sticky_S`).

---

## Validation evidence (commercial reference simulator, on the literal patched `hdl/*.sv`)

All on master `917dd79c` + patch, against `examples/pulp_divsqrt_fp32_tb.sv`
(21 rows: 4 sanity + 17 witnesses). `base` = pristine master, `PR-A` = +0001,
`PR-A+B` = +0001+0002.

### 17-witness TB (FP32 / RNE) — simulator-validated

| Tree | PASS / 21 | FAIL | Remaining failures |
|------|-----------|------|--------------------|
| base (pristine master) | 12 | 9 | (a)×2, (b)×5, (f)×2 (c/d/e already PASS via #16/#18) |
| **PR-A** (b + f) | **19** | 2 | only family (a) ×2 (1-ulp-low; flags now correct, NX=1) |
| **PR-A+B** (b + f + a round-up) | **21** | 0 | — |

Per-family on master:

| Family | base (master) | PR-A | PR-A+B | status |
|--------|---------------|------|--------|--------|
| (a) 1-ulp-low ×2 | FAIL | FAIL (flags now OK) | **PASS** | open until PR-B |
| (b) NX-on-inexact ×5 | FAIL | **PASS** | PASS | fixed by PR-A |
| (c) OF-without-NX ×4 | PASS | PASS | PASS | already #16 |
| (d) UF-without-NX ×3 | PASS | PASS | PASS | already #16 |
| (e) DZ-on-0/0 ×1 | PASS | PASS | PASS | already #18 |
| (f) spurious OF ×2 | FAIL | **PASS** | PASS | fixed by PR-A |

### Sqrt no-regression (FP32 / RNE) — simulator-validated

14 FP32 sqrt operands diffed base (master) vs PR-A vs PR-A+B:

* **13/14 vectors bit-identical** (result and flags).
* **1 intended improvement**: `sqrt(+inf)` flags `00101 → 00000` (spurious OF
  dropped) under PR-A and PR-A+B — the family-(f) inf-branch fix also covers the
  sqrt(+inf) path, i.e. it **fixes upstream #25** (`fsqrt` OF-on-infinity) as a
  side effect, result bit `7f800000` unchanged.
* PR-B changes **none** of the 14 sqrt vectors — the round-up term is
  `Div_enable_SI`-gated.

### Lean machine-certification (sorry-free)

`MOX/FloatSpec/PulpDivsqrtCertificates.lean` certifies, by closed evaluation of
the translated RTL against an executable IEEE-754 spec (`Float32.divSpec`,
Flocq-cross-checked): the unmodified unit produces the catalogued result/flag
pairs and each diverges; the corrected unit matches the spec on all 17 former
witnesses + 4 sanity rows. The certified model is the flattened mox-ingested
form; `norm`/`top`/`nrbd` module bodies are byte-identical to the literal
patched `hdl/`, `control_mvp` differs only by one fix-orthogonal generate-loop→
vector translator normalization. (The certificate currently encodes the
pin-form fix for c/d/e; for master those families are covered by #16/#18 and the
certificate's corrected-unit theorems remain valid as upper-bound evidence.)

---

## Tier A / Tier B PR plan

* **PR-A** — "DivSqrt: assert NX on inexact divides with correct result bits
  (family b); drop spurious OF on inf-operand divide/sqrt (family f, closes #25)".
  Patch `0001`. Result bits unchanged; simulator-validated (FP32/RNE).
* **PR-B** — "DivSqrt: round FP divide to nearest using the final-remainder
  sticky (fixes 1-ulp-low quotients)". Patch `0002`. Family a. Marked **needs
  sqrt + multi-format/multi-RM regression**; depends on PR-A.
* Optional follow-up — tighten #16's UF→NX to `Exp_UF_S & In_Exact_S` so exact
  subnormals don't carry spurious NX (see Refinement note).

